### PR TITLE
Added song screen w/ basic metadata and queueing functionality

### DIFF
--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
     "qrcode": "^1.4.4",
     "react": "^17.0.1",
     "react-dom": "^17.0.1",
-    "react-relay": "^10.1.0",
+    "react-relay": "^11.0.0",
     "react-router-dom": "^5.2.0",
     "relay-runtime": "^10.1.0"
   },
@@ -34,7 +34,7 @@
     "@types/qrcode": "^1.3.5",
     "@types/react": "^16.9.53",
     "@types/react-dom": "^16.9.8",
-    "@types/react-relay": "^7.0.17",
+    "@types/react-relay": "^11.0.0",
     "@types/react-router-dom": "^5.1.6",
     "@types/webpack-env": "^1.15.3",
     "babel-loader": "^8.2.2",

--- a/src/common/schema.graphql
+++ b/src/common/schema.graphql
@@ -2,6 +2,7 @@ type Query {
   wanIpAddress: String!
   songsByName(name: String): [Song!]!
   songsByIds(ids: [String!]!): [Song!]!
+  songsInQueue: [Song!]!
 }
 
 type Mutation {

--- a/src/common/schema.graphql
+++ b/src/common/schema.graphql
@@ -1,6 +1,11 @@
 type Query {
   wanIpAddress: String!
   songsByName(name: String): [Song!]!
+  songsByIds(ids: [String!]!): [Song!]!
+}
+
+type Mutation {
+  queueSong(id: String!): Boolean!
 }
 
 type Artist {
@@ -12,4 +17,5 @@ type Song {
   id: ID!
   name: String!
   artistName: String!
+  lyricsPreview: String
 }

--- a/src/main/damApi.ts
+++ b/src/main/damApi.ts
@@ -1,5 +1,31 @@
 import fetch from "node-fetch";
 
+const BASE_DK_DENMOKU_REQUEST = {
+  appVer: "2.1.0",
+  deviceId: "deviceId",
+};
+
+interface DkdenmokuResponse {
+  // There are literally no useful fields
+  appVer: string;
+}
+
+function makeDkdenmokuRequest<T extends DkdenmokuResponse>(
+  url: string,
+  data: any
+) {
+  return fetch(url, {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify({
+      ...BASE_DK_DENMOKU_REQUEST,
+      ...data,
+    }),
+  })
+    .then((res) => res.json())
+    .then((json: T) => json);
+}
+
 const BASE_DKWEBSYS_REQUEST = {
   modelTypeCode: "2",
   minseiModelNum: "M1",
@@ -60,4 +86,24 @@ function searchMusicByKeyword(keyword: string) {
   );
 }
 
-export { searchMusicByKeyword };
+interface DkDamIsExistServletResponse extends DkdenmokuResponse {
+  isExist: {
+    artistName: string;
+    firstBars: string;
+    reqNo: string;
+    songName: string;
+  }[];
+}
+
+function dkDamIsExistServlet(reqNos: string[]) {
+  return makeDkdenmokuRequest<DkDamIsExistServletResponse>(
+    "https://denmoku.clubdam.com/dkdenmoku/DkDamIsExistServlet",
+    {
+      isExist: reqNos.map((reqNo) => ({
+        reqNo: reqNo.replace("-", ""),
+      })),
+    }
+  );
+}
+
+export { dkDamIsExistServlet, searchMusicByKeyword };

--- a/src/main/graphql.ts
+++ b/src/main/graphql.ts
@@ -65,6 +65,15 @@ const resolvers = {
         }))
       );
     },
+    songsInQueue: () =>
+      dkDamIsExistServlet(db.songQueue).then((json) =>
+        json.isExist.map((song) => ({
+          id: song.reqNo,
+          name: song.songName,
+          artistName: song.artistName,
+          lyricsPreview: song.firstBars,
+        }))
+      ),
   },
   Mutation: {
     queueSong: (_: any, args: { id: string }): Promise<boolean> => {

--- a/src/remocon/App.tsx
+++ b/src/remocon/App.tsx
@@ -41,13 +41,15 @@ function App() {
           </li>
         </ul>
 
-        <Switch>
-          <Route path="/song/:id" component={Song} />
-          <Route path="/search">
-            <SongSearch />
-          </Route>
-          <Route path="/">controls</Route>
-        </Switch>
+        <div className="container">
+          <Switch>
+            <Route path="/song/:id" component={Song} />
+            <Route path="/search">
+              <SongSearch />
+            </Route>
+            <Route path="/">controls</Route>
+          </Switch>
+        </div>
       </div>
     </HashRouter>
   );

--- a/src/remocon/App.tsx
+++ b/src/remocon/App.tsx
@@ -5,6 +5,7 @@ import { HashRouter, Switch, Route, Link } from "react-router-dom";
 import M from "materialize-css";
 import "materialize-css/dist/css/materialize.css"; // tslint:disable-line:no-submodule-imports
 
+import Controls from "./Controls";
 import Song from "./Song";
 import SongSearch from "./SongSearch";
 
@@ -47,7 +48,9 @@ function App() {
             <Route path="/search">
               <SongSearch />
             </Route>
-            <Route path="/">controls</Route>
+            <Route path="/">
+              <Controls />
+            </Route>
           </Switch>
         </div>
       </div>

--- a/src/remocon/Controls.tsx
+++ b/src/remocon/Controls.tsx
@@ -1,0 +1,35 @@
+import React from "react";
+import { graphql, useLazyLoadQuery, useMutation } from "react-relay";
+import { Link } from "react-router-dom";
+
+import { withLoader } from "./components/Loader";
+import { ControlsQuery } from "./__generated__/ControlsQuery.graphql";
+
+const controlsQuery = graphql`
+  query ControlsQuery {
+    songsInQueue {
+      id
+      name
+      artistName
+    }
+  }
+`;
+
+const Controls = () => {
+  const data = useLazyLoadQuery<ControlsQuery>(controlsQuery, {});
+  return (
+    <div className="collection">
+      {data.songsInQueue.map((song, i) => (
+        <Link
+          key={`${song.id}_${i}`}
+          className="collection-item"
+          to={`/song/${song.id}`}
+        >
+          {song.artistName} - {song.name}
+        </Link>
+      ))}
+    </div>
+  );
+};
+
+export default withLoader(Controls);

--- a/src/remocon/Song.tsx
+++ b/src/remocon/Song.tsx
@@ -9,7 +9,6 @@ import { SongQuery } from "./__generated__/SongQuery.graphql";
 const songQuery = graphql`
   query SongQuery($id: String!) {
     songsByIds(ids: [$id]) {
-      id
       name
       artistName
       lyricsPreview

--- a/src/remocon/Song.tsx
+++ b/src/remocon/Song.tsx
@@ -1,9 +1,27 @@
-import React, { useEffect, useRef, useState } from "react";
-import { graphql, QueryRenderer } from "react-relay";
+import React, { useState } from "react";
+import { graphql, useLazyLoadQuery, useMutation } from "react-relay";
 import { RouteComponentProps } from "react-router-dom";
 
-import environment from "../common/graphqlEnvironment";
-import { SongSearchQuery } from "./__generated__/SongSearchQuery.graphql";
+import { withLoader } from "./components/Loader";
+import { SongMutation } from "./__generated__/SongMutation.graphql";
+import { SongQuery } from "./__generated__/SongQuery.graphql";
+
+const songQuery = graphql`
+  query SongQuery($id: String!) {
+    songsByIds(ids: [$id]) {
+      id
+      name
+      artistName
+      lyricsPreview
+    }
+  }
+`;
+
+const songMutation = graphql`
+  mutation SongMutation($id: String!) {
+    queueSong(id: $id)
+  }
+`;
 
 interface SongParams {
   id: string;
@@ -11,7 +29,38 @@ interface SongParams {
 
 interface Props extends RouteComponentProps<SongParams> {}
 
-function SongSearch(props: Props) {
-  return <div>{props.match.params.id}</div>;
+function Song(props: Props) {
+  const { id } = props.match.params;
+  const [queued, setQueued] = useState(false);
+  const data = useLazyLoadQuery<SongQuery>(songQuery, { id });
+  const [commit, isInFlight] = useMutation<SongMutation>(songMutation);
+
+  const { name, artistName, lyricsPreview } = data.songsByIds[0];
+
+  const onClickQueueSong = () => {
+    commit({
+      variables: { id },
+      onCompleted: ({ queueSong }) => setQueued(queueSong),
+    });
+  };
+
+  return (
+    <div className="card">
+      <div className="card-content">
+        <h6>{artistName}</h6>
+        <h5>{name}</h5>
+        {!!lyricsPreview && <blockquote>{lyricsPreview} ...</blockquote>}
+      </div>
+      <div className="card-action">
+        <button
+          className={`waves-effect waves-light btn ${queued ? "disabled" : ""}`}
+          onClick={onClickQueueSong}
+        >
+          {queued ? "Queued!" : "Queue song"}
+        </button>
+      </div>
+    </div>
+  );
 }
-export default SongSearch;
+
+export default withLoader(Song);

--- a/src/remocon/__generated__/ControlsQuery.graphql.ts
+++ b/src/remocon/__generated__/ControlsQuery.graphql.ts
@@ -1,0 +1,94 @@
+/* tslint:disable */
+/* eslint-disable */
+// @ts-nocheck
+
+import { ConcreteRequest } from "relay-runtime";
+export type ControlsQueryVariables = {};
+export type ControlsQueryResponse = {
+    readonly songsInQueue: ReadonlyArray<{
+        readonly id: string;
+        readonly name: string;
+        readonly artistName: string;
+    }>;
+};
+export type ControlsQuery = {
+    readonly response: ControlsQueryResponse;
+    readonly variables: ControlsQueryVariables;
+};
+
+
+
+/*
+query ControlsQuery {
+  songsInQueue {
+    id
+    name
+    artistName
+  }
+}
+*/
+
+const node: ConcreteRequest = (function(){
+var v0 = [
+  {
+    "alias": null,
+    "args": null,
+    "concreteType": "Song",
+    "kind": "LinkedField",
+    "name": "songsInQueue",
+    "plural": true,
+    "selections": [
+      {
+        "alias": null,
+        "args": null,
+        "kind": "ScalarField",
+        "name": "id",
+        "storageKey": null
+      },
+      {
+        "alias": null,
+        "args": null,
+        "kind": "ScalarField",
+        "name": "name",
+        "storageKey": null
+      },
+      {
+        "alias": null,
+        "args": null,
+        "kind": "ScalarField",
+        "name": "artistName",
+        "storageKey": null
+      }
+    ],
+    "storageKey": null
+  }
+];
+return {
+  "fragment": {
+    "argumentDefinitions": [],
+    "kind": "Fragment",
+    "metadata": null,
+    "name": "ControlsQuery",
+    "selections": (v0/*: any*/),
+    "type": "Query",
+    "abstractKey": null
+  },
+  "kind": "Request",
+  "operation": {
+    "argumentDefinitions": [],
+    "kind": "Operation",
+    "name": "ControlsQuery",
+    "selections": (v0/*: any*/)
+  },
+  "params": {
+    "cacheID": "63da096f76b04898d06821f3c5256e23",
+    "id": null,
+    "metadata": {},
+    "name": "ControlsQuery",
+    "operationKind": "query",
+    "text": "query ControlsQuery {\n  songsInQueue {\n    id\n    name\n    artistName\n  }\n}\n"
+  }
+};
+})();
+(node as any).hash = 'b4341b584fc0d83c8ab4a8fbc4cb09fd';
+export default node;

--- a/src/remocon/__generated__/SongMutation.graphql.ts
+++ b/src/remocon/__generated__/SongMutation.graphql.ts
@@ -1,0 +1,78 @@
+/* tslint:disable */
+/* eslint-disable */
+// @ts-nocheck
+
+import { ConcreteRequest } from "relay-runtime";
+export type SongMutationVariables = {
+    id: string;
+};
+export type SongMutationResponse = {
+    readonly queueSong: boolean;
+};
+export type SongMutation = {
+    readonly response: SongMutationResponse;
+    readonly variables: SongMutationVariables;
+};
+
+
+
+/*
+mutation SongMutation(
+  $id: String!
+) {
+  queueSong(id: $id)
+}
+*/
+
+const node: ConcreteRequest = (function(){
+var v0 = [
+  {
+    "defaultValue": null,
+    "kind": "LocalArgument",
+    "name": "id"
+  }
+],
+v1 = [
+  {
+    "alias": null,
+    "args": [
+      {
+        "kind": "Variable",
+        "name": "id",
+        "variableName": "id"
+      }
+    ],
+    "kind": "ScalarField",
+    "name": "queueSong",
+    "storageKey": null
+  }
+];
+return {
+  "fragment": {
+    "argumentDefinitions": (v0/*: any*/),
+    "kind": "Fragment",
+    "metadata": null,
+    "name": "SongMutation",
+    "selections": (v1/*: any*/),
+    "type": "Mutation",
+    "abstractKey": null
+  },
+  "kind": "Request",
+  "operation": {
+    "argumentDefinitions": (v0/*: any*/),
+    "kind": "Operation",
+    "name": "SongMutation",
+    "selections": (v1/*: any*/)
+  },
+  "params": {
+    "cacheID": "d478440211a2642eaa3238a5dfa758b9",
+    "id": null,
+    "metadata": {},
+    "name": "SongMutation",
+    "operationKind": "mutation",
+    "text": "mutation SongMutation(\n  $id: String!\n) {\n  queueSong(id: $id)\n}\n"
+  }
+};
+})();
+(node as any).hash = 'b7b00a49d57720a83be6a8b3d1441202';
+export default node;

--- a/src/remocon/__generated__/SongQuery.graphql.ts
+++ b/src/remocon/__generated__/SongQuery.graphql.ts
@@ -8,7 +8,6 @@ export type SongQueryVariables = {
 };
 export type SongQueryResponse = {
     readonly songsByIds: ReadonlyArray<{
-        readonly id: string;
         readonly name: string;
         readonly artistName: string;
         readonly lyricsPreview: string | null;
@@ -26,10 +25,10 @@ query SongQuery(
   $id: String!
 ) {
   songsByIds(ids: [$id]) {
-    id
     name
     artistName
     lyricsPreview
+    id
   }
 }
 */
@@ -44,64 +43,60 @@ var v0 = [
 ],
 v1 = [
   {
-    "alias": null,
-    "args": [
+    "items": [
       {
-        "items": [
-          {
-            "kind": "Variable",
-            "name": "ids.0",
-            "variableName": "id"
-          }
-        ],
-        "kind": "ListValue",
-        "name": "ids"
+        "kind": "Variable",
+        "name": "ids.0",
+        "variableName": "id"
       }
     ],
-    "concreteType": "Song",
-    "kind": "LinkedField",
-    "name": "songsByIds",
-    "plural": true,
-    "selections": [
-      {
-        "alias": null,
-        "args": null,
-        "kind": "ScalarField",
-        "name": "id",
-        "storageKey": null
-      },
-      {
-        "alias": null,
-        "args": null,
-        "kind": "ScalarField",
-        "name": "name",
-        "storageKey": null
-      },
-      {
-        "alias": null,
-        "args": null,
-        "kind": "ScalarField",
-        "name": "artistName",
-        "storageKey": null
-      },
-      {
-        "alias": null,
-        "args": null,
-        "kind": "ScalarField",
-        "name": "lyricsPreview",
-        "storageKey": null
-      }
-    ],
-    "storageKey": null
+    "kind": "ListValue",
+    "name": "ids"
   }
-];
+],
+v2 = {
+  "alias": null,
+  "args": null,
+  "kind": "ScalarField",
+  "name": "name",
+  "storageKey": null
+},
+v3 = {
+  "alias": null,
+  "args": null,
+  "kind": "ScalarField",
+  "name": "artistName",
+  "storageKey": null
+},
+v4 = {
+  "alias": null,
+  "args": null,
+  "kind": "ScalarField",
+  "name": "lyricsPreview",
+  "storageKey": null
+};
 return {
   "fragment": {
     "argumentDefinitions": (v0/*: any*/),
     "kind": "Fragment",
     "metadata": null,
     "name": "SongQuery",
-    "selections": (v1/*: any*/),
+    "selections": [
+      {
+        "alias": null,
+        "args": (v1/*: any*/),
+        "concreteType": "Song",
+        "kind": "LinkedField",
+        "name": "songsByIds",
+        "plural": true,
+        "selections": [
+          (v2/*: any*/),
+          (v3/*: any*/),
+          (v4/*: any*/)
+        ],
+        "storageKey": null
+      }
+    ],
     "type": "Query",
     "abstractKey": null
   },
@@ -110,17 +105,39 @@ return {
     "argumentDefinitions": (v0/*: any*/),
     "kind": "Operation",
     "name": "SongQuery",
-    "selections": (v1/*: any*/)
+    "selections": [
+      {
+        "alias": null,
+        "args": (v1/*: any*/),
+        "concreteType": "Song",
+        "kind": "LinkedField",
+        "name": "songsByIds",
+        "plural": true,
+        "selections": [
+          (v2/*: any*/),
+          (v3/*: any*/),
+          (v4/*: any*/),
+          {
+            "alias": null,
+            "args": null,
+            "kind": "ScalarField",
+            "name": "id",
+            "storageKey": null
+          }
+        ],
+        "storageKey": null
+      }
+    ]
   },
   "params": {
-    "cacheID": "7fa68f8678b5eaaef240a8a19a25b40c",
+    "cacheID": "eadd96a908c4854187ad344b41488aea",
     "id": null,
     "metadata": {},
     "name": "SongQuery",
     "operationKind": "query",
-    "text": "query SongQuery(\n  $id: String!\n) {\n  songsByIds(ids: [$id]) {\n    id\n    name\n    artistName\n    lyricsPreview\n  }\n}\n"
+    "text": "query SongQuery(\n  $id: String!\n) {\n  songsByIds(ids: [$id]) {\n    name\n    artistName\n    lyricsPreview\n    id\n  }\n}\n"
   }
 };
 })();
-(node as any).hash = 'bce3e15ca1bea147697e09268f3f3683';
+(node as any).hash = '7e38c217f0af5103d1fee0c6b9443102';
 export default node;

--- a/src/remocon/__generated__/SongQuery.graphql.ts
+++ b/src/remocon/__generated__/SongQuery.graphql.ts
@@ -1,0 +1,126 @@
+/* tslint:disable */
+/* eslint-disable */
+// @ts-nocheck
+
+import { ConcreteRequest } from "relay-runtime";
+export type SongQueryVariables = {
+    id: string;
+};
+export type SongQueryResponse = {
+    readonly songsByIds: ReadonlyArray<{
+        readonly id: string;
+        readonly name: string;
+        readonly artistName: string;
+        readonly lyricsPreview: string | null;
+    }>;
+};
+export type SongQuery = {
+    readonly response: SongQueryResponse;
+    readonly variables: SongQueryVariables;
+};
+
+
+
+/*
+query SongQuery(
+  $id: String!
+) {
+  songsByIds(ids: [$id]) {
+    id
+    name
+    artistName
+    lyricsPreview
+  }
+}
+*/
+
+const node: ConcreteRequest = (function(){
+var v0 = [
+  {
+    "defaultValue": null,
+    "kind": "LocalArgument",
+    "name": "id"
+  }
+],
+v1 = [
+  {
+    "alias": null,
+    "args": [
+      {
+        "items": [
+          {
+            "kind": "Variable",
+            "name": "ids.0",
+            "variableName": "id"
+          }
+        ],
+        "kind": "ListValue",
+        "name": "ids"
+      }
+    ],
+    "concreteType": "Song",
+    "kind": "LinkedField",
+    "name": "songsByIds",
+    "plural": true,
+    "selections": [
+      {
+        "alias": null,
+        "args": null,
+        "kind": "ScalarField",
+        "name": "id",
+        "storageKey": null
+      },
+      {
+        "alias": null,
+        "args": null,
+        "kind": "ScalarField",
+        "name": "name",
+        "storageKey": null
+      },
+      {
+        "alias": null,
+        "args": null,
+        "kind": "ScalarField",
+        "name": "artistName",
+        "storageKey": null
+      },
+      {
+        "alias": null,
+        "args": null,
+        "kind": "ScalarField",
+        "name": "lyricsPreview",
+        "storageKey": null
+      }
+    ],
+    "storageKey": null
+  }
+];
+return {
+  "fragment": {
+    "argumentDefinitions": (v0/*: any*/),
+    "kind": "Fragment",
+    "metadata": null,
+    "name": "SongQuery",
+    "selections": (v1/*: any*/),
+    "type": "Query",
+    "abstractKey": null
+  },
+  "kind": "Request",
+  "operation": {
+    "argumentDefinitions": (v0/*: any*/),
+    "kind": "Operation",
+    "name": "SongQuery",
+    "selections": (v1/*: any*/)
+  },
+  "params": {
+    "cacheID": "7fa68f8678b5eaaef240a8a19a25b40c",
+    "id": null,
+    "metadata": {},
+    "name": "SongQuery",
+    "operationKind": "query",
+    "text": "query SongQuery(\n  $id: String!\n) {\n  songsByIds(ids: [$id]) {\n    id\n    name\n    artistName\n    lyricsPreview\n  }\n}\n"
+  }
+};
+})();
+(node as any).hash = 'bce3e15ca1bea147697e09268f3f3683';
+export default node;

--- a/src/remocon/components/Loader.tsx
+++ b/src/remocon/components/Loader.tsx
@@ -1,0 +1,32 @@
+import React, { Suspense } from "react";
+
+const Loader = () => (
+  <div className="preloader-wrapper big active">
+    <div className="spinner-layer spinner-red-only">
+      <div className="circle-clipper left">
+        <div className="circle"></div>
+      </div>
+      <div className="gap-patch">
+        <div className="circle"></div>
+      </div>
+      <div className="circle-clipper right">
+        <div className="circle"></div>
+      </div>
+    </div>
+  </div>
+);
+
+export const withLoader = <P extends object>(
+  WrappedComponent: React.ComponentType<P>
+) =>
+  class WithLoader extends React.Component<P> {
+    render() {
+      return (
+        <Suspense fallback={<Loader />}>
+          <WrappedComponent {...(this.props as P)} />
+        </Suspense>
+      );
+    }
+  };
+
+export default Loader;

--- a/src/remocon/index.tsx
+++ b/src/remocon/index.tsx
@@ -1,11 +1,15 @@
 import React from "react";
 import ReactDOM from "react-dom";
+import { RelayEnvironmentProvider } from "react-relay";
 
+import environment from "../common/graphqlEnvironment";
 import App from "./App";
 
 ReactDOM.render(
   <React.StrictMode>
-    <App />
+    <RelayEnvironmentProvider environment={environment}>
+      <App />
+    </RelayEnvironmentProvider>
   </React.StrictMode>,
   document.getElementById("root")
 );

--- a/yarn.lock
+++ b/yarn.lock
@@ -1380,10 +1380,10 @@
   dependencies:
     "@types/react" "^16"
 
-"@types/react-relay@^7.0.17":
-  version "7.0.17"
-  resolved "https://registry.yarnpkg.com/@types/react-relay/-/react-relay-7.0.17.tgz#83f6b85c41b5fd3bb27d04d759fa4c0e4dd6a8d4"
-  integrity sha512-cJqOFIbp3M3/QkRpxlL4pwWRWB0lPGHevJFW8unuebkkITre8ptgknkGhAKe5IlA6ENTRJqVQXMuNdyLxl+0cQ==
+"@types/react-relay@^11.0.0":
+  version "11.0.1"
+  resolved "https://registry.yarnpkg.com/@types/react-relay/-/react-relay-11.0.1.tgz#5750409b4323f871910a52b514daab09aa4f4c75"
+  integrity sha512-mp9HUfaFcuynWNGpuS6GJEgIkQMeUvaVZ0KNLeJp21aAwsSajeU7vVH4uttSHk9iEvfw8ZyF5fqZHzKpCOeIDQ==
   dependencies:
     "@types/react" "*"
     "@types/relay-runtime" "*"
@@ -6088,15 +6088,16 @@ react-is@^16.6.0, react-is@^16.7.0, react-is@^16.8.1:
   resolved "https://registry.yarnpkg.com/react-is/-/react-is-16.13.1.tgz#789729a4dc36de2999dc156dd6c1d9c18cea56a4"
   integrity sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ==
 
-react-relay@^10.1.0:
-  version "10.1.0"
-  resolved "https://registry.yarnpkg.com/react-relay/-/react-relay-10.1.0.tgz#49c6d34b50cf7f99c3d28327bb804ee9bf756023"
-  integrity sha512-xtjgtrVTxIji2VWtlOA+93eVo3uNtZI1aFgRAOaQ58ITLNB3gMAlFX6V4u25XJKKWCIEL1GmVdGSiZQ0So6zYA==
+react-relay@^11.0.0:
+  version "11.0.2"
+  resolved "https://registry.yarnpkg.com/react-relay/-/react-relay-11.0.2.tgz#5f77e30e0d592f19c641e5dcc42f5d828bd16da5"
+  integrity sha512-RxtLBl8nxbaP26RcNDtKMrUBuJB5kFCCI4aZxnZByoncgovDgtewAsMiwcI8aDA8FjmXWRAtAAckh8DkMsMp7Q==
   dependencies:
     "@babel/runtime" "^7.0.0"
     fbjs "^3.0.0"
+    invariant "^2.2.4"
     nullthrows "^1.1.1"
-    relay-runtime "10.1.0"
+    relay-runtime "11.0.2"
 
 react-router-dom@^5.2.0:
   version "5.2.0"
@@ -6334,6 +6335,15 @@ relay-runtime@10.1.0, relay-runtime@^10.1.0:
   dependencies:
     "@babel/runtime" "^7.0.0"
     fbjs "^3.0.0"
+
+relay-runtime@11.0.2:
+  version "11.0.2"
+  resolved "https://registry.yarnpkg.com/relay-runtime/-/relay-runtime-11.0.2.tgz#c3650477d45665b9628b852b35f203e361ad55e8"
+  integrity sha512-xxZkIRnL8kNE1cxmwDXX8P+wSeWLR+0ACFyAiAhvfWWAyjXb+bhjJ2FSsRGlNYfkqaTNEuDqpnodQV1/fF7Idw==
+  dependencies:
+    "@babel/runtime" "^7.0.0"
+    fbjs "^3.0.0"
+    invariant "^2.2.4"
 
 remove-trailing-separator@^1.0.1:
   version "1.1.0"


### PR DESCRIPTION
User can now go from searching a song to queueing, to viewing queue.
Song queue is just stored in mem for now. /shrug

Search (existing):
![localhost_8080_(iPhone 6_7_8) (3)](https://user-images.githubusercontent.com/9064684/115950816-5ef18880-a492-11eb-9b49-f71a83f8caf0.png)

Song metadata:
![localhost_8080_(iPhone 6_7_8) (1)](https://user-images.githubusercontent.com/9064684/115950818-631da600-a492-11eb-938f-638436342576.png)

Queued:
![localhost_8080_(iPhone 6_7_8) (2)](https://user-images.githubusercontent.com/9064684/115950819-64e76980-a492-11eb-905c-0143e191c31b.png)

View queue:
![localhost_8080_(iPhone 6_7_8)](https://user-images.githubusercontent.com/9064684/115950821-66189680-a492-11eb-9b3b-ef5f2a860792.png)
